### PR TITLE
Fix: typo

### DIFF
--- a/albumy/__init__.py
+++ b/albumy/__init__.py
@@ -129,11 +129,11 @@ def register_commands(app):
 
     @app.cli.command()
     @click.option('--user', default=10, help='Quantity of users, default is 10.')
-    @click.option('--follow', default=30, help='Quantity of follows, default is 50.')
-    @click.option('--photo', default=30, help='Quantity of photos, default is 500.')
-    @click.option('--tag', default=20, help='Quantity of tags, default is 500.')
-    @click.option('--collect', default=50, help='Quantity of collects, default is 500.')
-    @click.option('--comment', default=100, help='Quantity of comments, default is 500.')
+    @click.option('--follow', default=30, help='Quantity of follows, default is 30.')
+    @click.option('--photo', default=30, help='Quantity of photos, default is 30.')
+    @click.option('--tag', default=20, help='Quantity of tags, default is 20.')
+    @click.option('--collect', default=50, help='Quantity of collects, default is 50.')
+    @click.option('--comment', default=100, help='Quantity of comments, default is 100.')
     def forge(user, follow, photo, tag, collect, comment):
         """Generate fake data."""
 


### PR DESCRIPTION
Fix typo in help message of albumy/__init__.py