### PR TITLE
fix: validate email in lowercase

### DIFF
--- a/albumy/forms/admin.py
+++ b/albumy/forms/admin.py
@@ -31,5 +31,5 @@ class EditProfileAdminForm(EditProfileForm):
             raise ValidationError('The username is already in use.')
 
     def validate_email(self, field):
-        if field.data != self.user.email and User.query.filter_by(email=field.data).first():
+        if field.data != self.user.email and User.query.filter_by(email=field.data.low()).first():
             raise ValidationError('The email is already in use.')

--- a/albumy/forms/auth.py
+++ b/albumy/forms/auth.py
@@ -32,7 +32,7 @@ class RegisterForm(FlaskForm):
     submit = SubmitField()
 
     def validate_email(self, field):
-        if User.query.filter_by(email=field.data).first():
+        if User.query.filter_by(email=field.data.low()).first():
             raise ValidationError('The email is already in use.')
 
     def validate_username(self, field):

--- a/albumy/forms/user.py
+++ b/albumy/forms/user.py
@@ -49,6 +49,10 @@ class ChangeEmailForm(FlaskForm):
     email = StringField('New Email', validators=[DataRequired(), Length(1, 254), Email()])
     submit = SubmitField()
 
+    def validate_email(self, field):
+        if User.query.filter_by(email=field.data.low()).first():
+            raise ValidationError('The email is already in use.')
+
 
 class ChangePasswordForm(FlaskForm):
     old_password = PasswordField('Old Password', validators=[DataRequired()])


### PR DESCRIPTION
注册时邮箱地址均以小写化写入数据库，在验证邮箱时也应该小写化后查询，否则已注册邮箱的大写形式将会通过验证。
另外更改邮箱地址时也应该在发送令牌前对新地址进行验证。